### PR TITLE
fix: catch ValueError in Tag::getBinary instead of dead falsy check

### DIFF
--- a/src/Pdu/Tag.php
+++ b/src/Pdu/Tag.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Smpp\Pdu;
 
 use Smpp\Exceptions\SmppInvalidArgumentException;
+use ValueError;
 
 /**
  * Primitive class to represent SMPP optional params,
@@ -112,15 +113,14 @@ class Tag
      */
     public function getBinary(): string
     {
-        $binary = pack('nn' . $this->type, $this->id, $this->length, $this->value);
-        if (!$binary) {
+        try {
+            return pack('nn' . $this->type, $this->id, $this->length, $this->value);
+        } catch (ValueError $e) {
             throw new SmppInvalidArgumentException(
-                'Format string contain errors, please check format: "'
-                . 'nn'
-                . $this->type
-                . '"'
+                'Format string contain errors, please check format: "nn' . $this->type . '"',
+                0,
+                $e
             );
         }
-        return $binary;
     }
 }

--- a/tests/Pdu/TagTest.php
+++ b/tests/Pdu/TagTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pdu;
+
+use PHPUnit\Framework\TestCase;
+use Smpp\Exceptions\SmppInvalidArgumentException;
+use Smpp\Pdu\Tag;
+
+class TagTest extends TestCase
+{
+    /**
+     * Round-trip: pack a string-valued TLV and verify the binary matches the
+     * raw `nn` + value layout (id, length, value) defined by SMPP v3.4 5.3.
+     *
+     * @throws SmppInvalidArgumentException
+     */
+    public function testGetBinaryPacksStringValueTlv(): void
+    {
+        $value = 'Hello';
+        $tag   = new Tag(Tag::MESSAGE_PAYLOAD, $value);
+
+        $binary = $tag->getBinary();
+
+        $expected = pack('nn', Tag::MESSAGE_PAYLOAD, strlen($value)) . $value;
+        $this->assertSame($expected, $binary);
+    }
+
+    /**
+     * Numeric TLV with explicit pack-type (single-byte unsigned char).
+     *
+     * @throws SmppInvalidArgumentException
+     */
+    public function testGetBinaryPacksIntegerValueTlv(): void
+    {
+        $tag = new Tag(Tag::SAR_SEGMENT_SEQNUM, 3, 1, 'c');
+
+        $binary = $tag->getBinary();
+
+        $expected = pack('nnc', Tag::SAR_SEGMENT_SEQNUM, 1, 3);
+        $this->assertSame($expected, $binary);
+    }
+
+    /**
+     * pack() in PHP 8 throws ValueError on a malformed format string instead
+     * of returning false. getBinary() must convert that into the documented
+     * SmppInvalidArgumentException for callers.
+     */
+    public function testGetBinaryThrowsSmppExceptionOnInvalidPackFormat(): void
+    {
+        $tag = new Tag(Tag::USER_MESSAGE_REFERENCE, 'value', 5, 'k');
+
+        $this->expectException(SmppInvalidArgumentException::class);
+        $tag->getBinary();
+    }
+}


### PR DESCRIPTION
## Summary
Replaces the dead `if (!$binary)` check in `Tag::getBinary()` with a proper `try/catch` around `pack()`.

In PHP 8 `pack()` throws `ValueError` on malformed format strings rather than returning `false`, so the previous fallthrough into `SmppInvalidArgumentException` was unreachable and callers got a raw `ValueError` instead of the documented exception type.

## Changes
- `src/Pdu/Tag.php` — wrap `pack()` in `try/catch (ValueError)`, re-throw as `SmppInvalidArgumentException` with the original `ValueError` chained as `$previous`.
- `tests/Pdu/TagTest.php` — new unit tests:
  - round-trip pack of a string-valued TLV (`MESSAGE_PAYLOAD`)
  - round-trip pack of an integer TLV with explicit pack type (`SAR_SEGMENT_SEQNUM`, `c`)
  - exception conversion for an unknown pack format code

## Notes
First in a series of small fixes from the recent code review. No behavioural change beyond converting `ValueError` → `SmppInvalidArgumentException`; previously the dead check would have done the same thing if `pack()` had still returned `false`.