### PR TITLE
fix: correct DeliveryReceipt types and date parsing regression

### DIFF
--- a/src/Pdu/DeliveryReceipt.php
+++ b/src/Pdu/DeliveryReceipt.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Smpp\Pdu;
 
-use InvalidArgumentException;
 use Smpp\Exceptions\SmppException;
 use Smpp\Exceptions\SmppInvalidArgumentException;
 
@@ -14,7 +13,7 @@ use Smpp\Exceptions\SmppInvalidArgumentException;
  */
 class DeliveryReceipt extends Sms
 {
-    public int    $id;
+    public string $messageId;
     public int    $sub;
     public int    $dlvrd;
     public int    $submitDate;
@@ -25,15 +24,18 @@ class DeliveryReceipt extends Sms
 
     /**
      * Parse a delivery receipt formatted as specified in SMPP v3.4 - Appendix B
-     * It accepts all chars except space as the message id
+     * It accepts all chars except space as the message id.
      *
-     * @throws InvalidArgumentException
+     * Date fields are accepted as either YYMMDDhhmm (10 digits, no seconds) or
+     * YYMMDDhhmmss (12 digits) per spec / common SMSC implementations.
+     *
+     * @throws SmppInvalidArgumentException
      * @throws SmppException
      */
     public function parseDeliveryReceipt(): void
     {
         $numMatches = preg_match(
-            '/^id:([^ ]+) sub:(\d{1,3}) dlvrd:(\d{3}) submit date:(\d{10,12}) done date:(\d{10,12}) stat:([A-Z ]{7}) err:(\d{2,3}) text:(.*)$/si',
+            '/^id:([^ ]+) sub:(\d{1,3}) dlvrd:(\d{3}) submit date:(\d{10}|\d{12}) done date:(\d{10}|\d{12}) stat:([A-Z ]{7}) err:(\d{2,3}) text:(.*)$/si',
             $this->message,
             $matches
         );
@@ -46,34 +48,36 @@ class DeliveryReceipt extends Sms
             );
         }
 
-        [
-            $matched,
-            $this->id,
-            $this->sub,
-            $this->dlvrd,
-            $submitDate,
-            $doneDate,
-            $this->stat,
-            $this->err,
-            $this->text
-        ] = $matches;
-
-        $this->submitDate = $this->convertDate($submitDate);
-        $this->doneDate   = $this->convertDate($doneDate);
+        $this->messageId  = $matches[1];
+        $this->sub        = (int)$matches[2];
+        $this->dlvrd      = (int)$matches[3];
+        $this->submitDate = $this->convertDate($matches[4]);
+        $this->doneDate   = $this->convertDate($matches[5]);
+        $this->stat       = $matches[6];
+        $this->err        = (int)$matches[7];
+        $this->text       = $matches[8];
     }
 
     /**
-     * @param string $date
-     * @return int
+     * Convert a YYMMDDhhmm[ss] datetime string into a UTC unix timestamp.
+     *
      * @throws SmppException
      */
     private function convertDate(string $date): int
     {
         $dateParts = str_split($date, 2);
+        // The receipt regex guarantees 10 or 12 digits → 5 or 6 chunks, but
+        // the type system can't prove that — guard explicitly so PHPStan can
+        // narrow array access below and we get a clear runtime error if
+        // convertDate is ever called from a path that skips the regex.
+        if (count($dateParts) < 5) {
+            throw new SmppException('Invalid date provided');
+        }
+
         $timestamp = gmmktime(
             (int)$dateParts[3],
             (int)$dateParts[4],
-            (int)$dateParts[5],
+            (int)($dateParts[5] ?? '0'),
             (int)$dateParts[1],
             (int)$dateParts[2],
             (int)$dateParts[0]

--- a/tests/Pdu/DeliveryReceiptTest.php
+++ b/tests/Pdu/DeliveryReceiptTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pdu;
+
+use PHPUnit\Framework\TestCase;
+use Smpp\Exceptions\SmppException;
+use Smpp\Exceptions\SmppInvalidArgumentException;
+use Smpp\Pdu\Address;
+use Smpp\Pdu\DeliveryReceipt;
+use Smpp\Protocol\Command;
+use Smpp\Smpp;
+
+class DeliveryReceiptTest extends TestCase
+{
+    /**
+     * Happy path with the common 10-digit date format (YYMMDDhhmm).
+     * Also exercises an alphanumeric message id, which previously triggered a
+     * TypeError because `$id` was declared `int` while preg_match yields strings.
+     *
+     * @throws SmppException
+     * @throws SmppInvalidArgumentException
+     */
+    public function testParseDeliveryReceiptWithTenDigitDates(): void
+    {
+        $receipt = $this->makeReceipt(
+            'id:abc123XYZ sub:001 dlvrd:001 submit date:1601011200 done date:1601011230 stat:DELIVRD err:000 text:Hello world'
+        );
+
+        $receipt->parseDeliveryReceipt();
+
+        self::assertSame('abc123XYZ', $receipt->messageId);
+        self::assertSame(1, $receipt->sub);
+        self::assertSame(1, $receipt->dlvrd);
+        // 2016-01-01 12:00:00 UTC, 2016-01-01 12:30:00 UTC
+        self::assertSame(1451649600, $receipt->submitDate);
+        self::assertSame(1451651400, $receipt->doneDate);
+        self::assertSame('DELIVRD', $receipt->stat);
+        self::assertSame(0, $receipt->err);
+        self::assertSame('Hello world', $receipt->text);
+    }
+
+    /**
+     * 12-digit date format (YYMMDDhhmmss) — seconds are honoured rather than
+     * silently truncated.
+     *
+     * @throws SmppException
+     * @throws SmppInvalidArgumentException
+     */
+    public function testParseDeliveryReceiptWithTwelveDigitDates(): void
+    {
+        $receipt = $this->makeReceipt(
+            'id:42 sub:002 dlvrd:002 submit date:160101120015 done date:160101123045 stat:EXPIRED err:042 text:'
+        );
+
+        $receipt->parseDeliveryReceipt();
+
+        self::assertSame('42', $receipt->messageId);
+        self::assertSame(2, $receipt->sub);
+        self::assertSame(2, $receipt->dlvrd);
+        // 2016-01-01 12:00:15 UTC, 2016-01-01 12:30:45 UTC
+        self::assertSame(1451649615, $receipt->submitDate);
+        self::assertSame(1451651445, $receipt->doneDate);
+        self::assertSame('EXPIRED', $receipt->stat);
+        self::assertSame(42, $receipt->err);
+        self::assertSame('', $receipt->text);
+    }
+
+    /**
+     * 11-digit dates were silently accepted by the old `\d{10,12}` pattern,
+     * producing garbage timestamps via str_split byte misalignment.
+     */
+    public function testParseDeliveryReceiptRejectsElevenDigitDate(): void
+    {
+        $receipt = $this->makeReceipt(
+            'id:abc sub:001 dlvrd:001 submit date:16010112000 done date:1601011230 stat:DELIVRD err:000 text:x'
+        );
+
+        $this->expectException(SmppInvalidArgumentException::class);
+        $receipt->parseDeliveryReceipt();
+    }
+
+    public function testParseDeliveryReceiptRejectsMalformedMessage(): void
+    {
+        $receipt = $this->makeReceipt('not a delivery receipt');
+
+        $this->expectException(SmppInvalidArgumentException::class);
+        $receipt->parseDeliveryReceipt();
+    }
+
+    private function makeReceipt(string $message): DeliveryReceipt
+    {
+        $source      = new Address('1234', Smpp::TON_INTERNATIONAL, Smpp::NPI_E164);
+        $destination = new Address('5678', Smpp::TON_INTERNATIONAL, Smpp::NPI_E164);
+
+        return new DeliveryReceipt(
+            id: Command::DELIVER_SM,
+            status: 0,
+            sequence: 1,
+            body: '',
+            serviceType: '',
+            source: $source,
+            destination: $destination,
+            esmClass: Smpp::ESM_DELIVER_SMSC_RECEIPT,
+            protocolId: 0,
+            priorityFlag: 0,
+            registeredDelivery: 0,
+            dataCoding: Smpp::DATA_CODING_DEFAULT,
+            message: $message,
+            tags: []
+        );
+    }
+}


### PR DESCRIPTION
## Summary
Fixes two related correctness bugs in `DeliveryReceipt::parseDeliveryReceipt()`:

### 1. Type mismatches under `strict_types=1` (TypeError on first use)
- `$id` was declared `public int $id` but received a string capture from `preg_match`, and also shadowed `Pdu::$id` (the PDU command id, semantically unrelated). Renamed to `public string $messageId` and removed the shadow — parent's `$id` (the PDU command id, accessed via `getId()`) is left untouched.
- `$sub`, `$dlvrd`, `$err` were declared `int` but received string captures; cast explicitly.

### 2. Date parsing regression
- Old regex allowed `\d{10,12}` — 11-digit dates were silently accepted and produced garbage timestamps via `str_split($date, 2)` byte misalignment (last chunk = 1 char → `(int)X = 0`).
- `convertDate()` had lost the `?? 0` fallback for seconds in a recent refactor — 10-digit dates (the most common per spec Appendix B) emitted an `undefined array key 5` notice on every call.

Tightened the regex to `\d{10}|\d{12}` and restored the fallback. Added a `count($dateParts) >= 5` guard so PHPStan can narrow the array access (and we get a clean runtime error rather than a `null` deref if `convertDate` is ever called from a path that bypasses the regex).

### Tests
- Round-trip both 10- and 12-digit date formats with verified UTC timestamps.
- Reject 11-digit dates (previously silently accepted).
- Reject malformed receipts.
- Use an alphanumeric `messageId` to exercise the type fix (previously `TypeError`).

## BC note
`$deliveryReceipt->id` is no longer overridden by `DeliveryReceipt`. Callers reading the parsed SMSC message id must now use `$deliveryReceipt->messageId`. The previous declaration was unreachable in strict mode anyway (TypeError on assignment), so no working caller can depend on the old behaviour.

## Follow-ups (NOT in this PR)
- `$message` is parsed as ASCII regardless of `data_coding`; UCS-2 receipts will still fail to match. Tracked separately.